### PR TITLE
Graph store

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,16 @@ GLOBAL OPTIONS:
    --help, -h  show help (default: false)
 ```
 
-Run `kctl`:
-```shell
-./kctl | dot -Tsvg > cluster.svg && open cluster.svg
-```
+`kctl` currently only supports building the graph of the the Kubernetes API objects and storing them in in-memory store. It allows to dump the graph in [DOT GraphViz](https://graphviz.gitlab.io/_pages/doc/info/lang.html) format. This can be piped into the [GraphViz](https://www.graphviz.org/) tool for further processing. `kctl` is in the pre-alpha state (if it can be called that at all!) and it's more of a debugging help tool at the moment as the focus of the project is the graph mapping.
 
-`kctl` currently only supports building the graph of the the Kubernetes API objects. It also allows to dump the resulting graph in [DOT GraphViz](https://graphviz.gitlab.io/_pages/doc/info/lang.html) format. This can be piped into the [GraphViz](https://www.graphviz.org/) tool for further processing.interact with the `kraph`. It's in the pre-alpha state (if it can be called that at all!).
-
-**NOTE:** You must have `kubeconfig` properly configured
+**NOTE:** You must have `kubeconfig` properly configured.
 
 ```shell
-$ ./kctl build k8s -dot | dot -Tsvg > cluster.svg && open cluster.svg
+$ ./kctl build k8s -format "dot" | dot -Tsvg > cluster.svg && open cluster.svg
 ```
+
+**NOTE:** `dot` format is the only available and default format so you can get the same results as above by running the command below, too:
+```shell
+$ ./kctl build k8s | dot -Tsvg > cluster.svg && open cluster.svg
+```
+

--- a/cmd/kctl/.gitignore
+++ b/cmd/kctl/.gitignore
@@ -1,0 +1,2 @@
+kctl
+/kctl

--- a/cmd/kctl/app/cmd/build/kubernetes.go
+++ b/cmd/kctl/app/cmd/build/kubernetes.go
@@ -10,7 +10,6 @@ import (
 	"github.com/milosgajdos/kraph/store"
 	"github.com/milosgajdos/kraph/store/memory"
 	"github.com/urfave/cli/v2"
-	"gonum.org/v1/gonum/graph"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -106,7 +105,7 @@ func getKubeConfig(masterURL, kubeconfig string) (*rest.Config, error) {
 	return config, nil
 }
 
-func graphToOut(g graph.Graph, format string) (string, error) {
+func graphToOut(g store.Graph, format string) (string, error) {
 	switch format {
 	case "dot":
 		dotGraph := g.(store.DOTGraph)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -7,6 +7,8 @@ var (
 	ErrNotImplemented = err.New("not implemented")
 	// ErrUnknownObject is returned when requesting an unknown object
 	ErrUnknownObject = err.New("unknown object")
-	// ErrUnknownEntity is return when requesting and unknown store entity
+	// ErrUnknownEntity is returned when requesting and unknown store entity
 	ErrUnknownEntity = err.New("unknown entity")
+	// ErrNodeNotFound is returned when a node could not be found
+	ErrNodeNotFound = err.New("node not found")
 )

--- a/store/entity/edge.go
+++ b/store/entity/edge.go
@@ -2,7 +2,6 @@ package entity
 
 import (
 	"github.com/milosgajdos/kraph/store"
-	"gonum.org/v1/gonum/graph"
 )
 
 // Edge is graph edge
@@ -29,20 +28,13 @@ func NewEdge(from, to store.Node, opts ...store.Option) store.Edge {
 }
 
 // From returns the from node of the edge
-func (e *Edge) From() graph.Node {
+func (e *Edge) From() store.Node {
 	return e.from
 }
 
 // To returns the to node of an edge
-func (e *Edge) To() graph.Node {
+func (e *Edge) To() store.Node {
 	return e.to
-}
-
-// ReversedEdge returns a copy of the edge with reversed nodes
-func (e *Edge) ReversedEdge() graph.Edge {
-	e.from, e.to = e.to, e.from
-
-	return e
 }
 
 // Weight returns the edge weight

--- a/store/entity/edge_test.go
+++ b/store/entity/edge_test.go
@@ -8,8 +8,8 @@ import (
 
 var (
 	weight     = 100.0
-	from       = &Node{Entity: New(), id: 1, name: "foo"}
-	to         = &Node{Entity: New(), id: 2, name: "bar"}
+	from       = &Node{Entity: New(), id: "fooID", name: "foo"}
+	to         = &Node{Entity: New(), id: "barID", name: "bar"}
 	eKey, eVal = "foo", "bar"
 )
 
@@ -25,20 +25,11 @@ func TestEdge(t *testing.T) {
 	e := NewEdge(from, to, store.Weight(weight), store.Meta(edgeMetadata))
 
 	if node := e.From(); node.ID() != from.id {
-		t.Errorf("expected from Node: %d, got: %d", from.id, node.ID())
+		t.Errorf("expected from Node: %s, got: %s", from.id, node.ID())
 	}
 
 	if node := e.To(); node.ID() != to.id {
-		t.Errorf("expected to Node: %d, got: %d", to.id, node.ID())
-	}
-}
-
-func TestReversedEdge(t *testing.T) {
-	edgeMetadata := newEdgeMeta()
-	e := NewEdge(from, to, store.Weight(weight), store.Meta(edgeMetadata))
-
-	if re := e.ReversedEdge(); re.From().ID() != to.ID() || re.To().ID() != from.ID() {
-		t.Errorf("expected from->to: %d->%d, got: %d->%d", to.ID(), from.ID(), re.From().ID(), re.To().ID())
+		t.Errorf("expected to Node: %s, got: %s", to.id, node.ID())
 	}
 }
 

--- a/store/entity/entity_test.go
+++ b/store/entity/entity_test.go
@@ -45,5 +45,21 @@ func TestEntityOpts(t *testing.T) {
 	if val := e.Metadata().Get(mkey); val.(int) != mval {
 		t.Errorf("expected metadata for key %s: %d, got: %d", mkey, mval, val)
 	}
+}
 
+func TestEntityAttrs(t *testing.T) {
+	a := store.NewAttributes()
+	akey, aval := "foo", "val"
+	a.Set(akey, aval)
+
+	m := store.NewMetadata()
+	mkey := "foo"
+	mval := 5
+	m.Set(mkey, mval)
+
+	e := New(store.Meta(m), store.EntAttrs(a))
+
+	if count := len(e.Attributes()); count == 0 {
+		t.Errorf("expected %d attributes, got: %d", len(a.Attributes()), count)
+	}
 }

--- a/store/entity/node.go
+++ b/store/entity/node.go
@@ -5,12 +5,12 @@ import "github.com/milosgajdos/kraph/store"
 // Node is graph node
 type Node struct {
 	store.Entity
-	id   int64
+	id   string
 	name string
 }
 
 // NewNode creates a new node and returns it
-func NewNode(id int64, name string, opts ...store.Option) store.Node {
+func NewNode(id string, name string, opts ...store.Option) store.Node {
 	return &Node{
 		Entity: New(opts...),
 		id:     id,
@@ -19,13 +19,8 @@ func NewNode(id int64, name string, opts ...store.Option) store.Node {
 }
 
 // ID returns node ID
-func (n *Node) ID() int64 {
+func (n *Node) ID() string {
 	return n.id
-}
-
-// Name returns node name
-func (n *Node) Name() string {
-	return n.name
 }
 
 // DOTID returns the node's DOT ID.

--- a/store/entity/node_test.go
+++ b/store/entity/node_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 var (
-	id         int64 = 100
-	name             = "foo"
-	nKey, nVal       = "foo", "bar"
+	id         = "fooID"
+	name       = "foo"
+	nKey, nVal = "foo", "bar"
 )
 
 func newNodeMeta() store.Metadata {
@@ -24,7 +24,7 @@ func TestNodeID(t *testing.T) {
 	node := NewNode(id, name, store.Meta(nodeMetadata))
 
 	if node.ID() != id {
-		t.Errorf("expected node ID: %d, got: %d", id, node.ID())
+		t.Errorf("expected node ID: %s, got: %s", id, node.ID())
 	}
 }
 

--- a/store/memory/edge.go
+++ b/store/memory/edge.go
@@ -1,0 +1,35 @@
+package memory
+
+import (
+	"github.com/milosgajdos/kraph/store"
+	"gonum.org/v1/gonum/graph"
+)
+
+type edge struct {
+	store.Edge
+	from   *node
+	to     *node
+	weight float64
+}
+
+// From returns the from node of the first non-nil edge, or nil.
+func (e *edge) From() graph.Node {
+	return e.from
+}
+
+// To returns the to node of the first non-nil edge, or nil.
+func (e *edge) To() graph.Node {
+	return e.to
+}
+
+// ReversedEdge returns a new Edge with the end point of the edges in the pair swapped
+func (e *edge) ReversedEdge() graph.Edge {
+	e.from, e.to = e.to, e.from
+
+	return e
+}
+
+// Weight returns edge weight
+func (e *edge) Weight() float64 {
+	return e.weight
+}

--- a/store/memory/memory_test.go
+++ b/store/memory/memory_test.go
@@ -95,65 +95,156 @@ func TestNewMemory(t *testing.T) {
 		t.Fatalf("failed to create memory store: %v", err)
 	}
 
-	// NOTE: this test is not needed, but I figured it would be nice
-	// to test type-switch into concrete implementation type
-	memStore := m.(*Memory)
 	expCount := 0
-	if nodeCount := memStore.Nodes().Len(); nodeCount != expCount {
+	if nodeCount := len(m.Nodes()); nodeCount != expCount {
 		t.Errorf("expected nodes: %d, got: %d", expCount, nodeCount)
 	}
 }
 
-func TestAddLinkDelete(t *testing.T) {
+func TestAddNode(t *testing.T) {
 	m, err := NewStore("testID")
 	if err != nil {
 		t.Fatalf("failed to create memory store: %v", err)
 	}
 
 	obj1 := mock.NewObject("foo", "bar", "fobar", "randomid", nil)
+
 	node1, err := m.Add(obj1)
 	if err != nil {
 		t.Fatalf("failed adding object to memory store: %v", err)
 	}
 
-	node1Obj := node1.Metadata().Get("object")
-	node1ApiObj := node1Obj.(api.Object)
-
-	if !reflect.DeepEqual(node1ApiObj, obj1) {
-		t.Errorf("expected object: %s, got: %s", obj1, node1ApiObj)
-	}
-
-	memStore := m.(*Memory)
 	expCount := 1
-	if nodeCount := memStore.Nodes().Len(); nodeCount != expCount {
+	if nodeCount := len(m.Nodes()); nodeCount != expCount {
 		t.Errorf("expected nodes: %d, got: %d", expCount, nodeCount)
 	}
 
+	if n := m.Node(node1.ID()); !reflect.DeepEqual(n, node1) {
+		t.Errorf("failed getting node %s, got: %v", node1.ID(), n)
+	}
+
+	// add the same node again
+	nodeX, err := m.Add(obj1)
+	if err != nil {
+		t.Fatalf("failed adding object to memory store: %v", err)
+	}
+
+	if !reflect.DeepEqual(node1, nodeX) {
+		t.Errorf("expected %s, got %s", node1.ID(), nodeX.ID())
+	}
+}
+
+func TestGetNode(t *testing.T) {
+	m, err := NewStore("testID")
+	if err != nil {
+		t.Fatalf("failed to create memory store: %v", err)
+	}
+
+	obj1 := mock.NewObject("foo", "bar", "fobar", "randomid", nil)
+
+	node1, err := m.Add(obj1)
+	if err != nil {
+		t.Fatalf("failed adding object to memory store: %v", err)
+	}
+
+	expCount := 1
+	if nodeCount := len(m.Nodes()); nodeCount != expCount {
+		t.Errorf("expected nodes: %d, got: %d", expCount, nodeCount)
+	}
+
+	if n := m.Node(node1.ID()); !reflect.DeepEqual(n, node1) {
+		t.Errorf("failed getting node %s, got: %v", node1.ID(), n)
+	}
+
+	if n := m.Node(""); n != nil {
+		t.Errorf("expected nil node, got: %#v", n)
+	}
+}
+
+func TestLink(t *testing.T) {
+	m, err := NewStore("testID")
+	if err != nil {
+		t.Fatalf("failed to create memory store: %v", err)
+	}
+
+	obj1 := mock.NewObject("foo", "bar", "fobar", "randomid", nil)
+
+	node1, err := m.Add(obj1)
+	if err != nil {
+		t.Fatalf("failed adding object to memory store: %v", err)
+	}
+
 	obj2 := mock.NewObject("foo2", "bar2", "fobar", "randomid2", nil)
+
 	node2, err := m.Add(obj2)
 	if err != nil {
 		t.Fatalf("failed adding object to memory store: %v", err)
 	}
 
-	node2Obj := node2.Metadata().Get("object")
-	node2ApiObj := node2Obj.(api.Object)
+	nodeX := entity.NewNode("nonEx", "nonEx")
 
-	if !reflect.DeepEqual(node2ApiObj, obj2) {
-		t.Errorf("expected object: %s, got: %s", obj2, node2ApiObj)
+	if _, err := m.Link(nodeX, node2); err != errors.ErrNodeNotFound {
+		t.Errorf("expected error %s, got: %#v", errors.ErrNodeNotFound, err)
 	}
 
-	expCount = 2
-	if nodeCount := memStore.Nodes().Len(); nodeCount != expCount {
-		t.Errorf("expected nodes: %d, got: %d", expCount, nodeCount)
+	if _, err := m.Link(node1, nodeX); err != errors.ErrNodeNotFound {
+		t.Errorf("expected error %s, got: %#v", errors.ErrNodeNotFound, err)
 	}
 
 	edge, err := m.Link(node1, node2)
 	if err != nil {
-		t.Errorf("failed to link %d to %d: %v", node1.ID(), node2.ID(), err)
+		t.Errorf("failed to link %s to %s: %v", node1.ID(), node2.ID(), err)
 	}
 
 	if w := edge.Weight(); big.NewFloat(w).Cmp(big.NewFloat(store.DefaultEdgeWeight)) != 0 {
 		t.Errorf("expected non-negative weight")
+	}
+
+	if e := m.Edge(node1.ID(), node2.ID()); e == nil {
+		t.Errorf("failed to find edge between %s and %s", node1.ID(), node2.ID())
+	}
+
+	exEdge, err := m.Link(node1, node2)
+	if err != nil {
+		t.Errorf("failed to link %s to %s: %v", node1.ID(), node2.ID(), err)
+	}
+
+	if !reflect.DeepEqual(exEdge, edge) {
+		t.Errorf("expected %#v, got: %#v", exEdge, edge)
+	}
+
+	if e := m.Edge("", node2.ID()); e != nil {
+		t.Errorf("expected nil edge, got: %#v", e)
+	}
+
+	if e := m.Edge(node1.ID(), ""); e != nil {
+		t.Errorf("expected nil edge, got: %#v", e)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	m, err := NewStore("testID")
+	if err != nil {
+		t.Fatalf("failed to create memory store: %v", err)
+	}
+
+	obj1 := mock.NewObject("foo", "bar", "fobar", "randomid", nil)
+
+	node1, err := m.Add(obj1)
+	if err != nil {
+		t.Fatalf("failed adding object to memory store: %v", err)
+	}
+
+	obj2 := mock.NewObject("foo2", "bar2", "fobar", "randomid2", nil)
+
+	node2, err := m.Add(obj2)
+	if err != nil {
+		t.Fatalf("failed adding object to memory store: %v", err)
+	}
+
+	edge, err := m.Link(node1, node2)
+	if err != nil {
+		t.Errorf("failed to link %s to %s: %v", node1.ID(), node2.ID(), err)
 	}
 
 	if err := m.Delete(edge); err != nil {
@@ -161,7 +252,7 @@ func TestAddLinkDelete(t *testing.T) {
 	}
 
 	if edge := m.Edge(node1.ID(), node2.ID()); edge != nil {
-		t.Errorf("expected to remove edge between %d-%d, got: %#v", node1.ID(), node2.ID(), edge)
+		t.Errorf("expected to remove edge between %s-%s, got: %#v", node1.ID(), node2.ID(), edge)
 	}
 
 	if err := m.Delete(node1); err != nil {
@@ -169,12 +260,24 @@ func TestAddLinkDelete(t *testing.T) {
 	}
 
 	if node := m.Node(node1.ID()); node != nil {
-		t.Errorf("expected to remove node: %d, got: %#v", node1.ID(), node)
+		t.Errorf("expected to remove node: %s, got: %#v", node1.ID(), node)
 	}
 
 	ent := entity.New()
 	if err := m.Delete(ent); err != errors.ErrUnknownEntity {
 		t.Errorf("expected: %v, got: %v", errors.ErrUnknownEntity, err)
+	}
+
+	nodeX := entity.NewNode("nonEx", "nonEx")
+
+	if err := m.Delete(nodeX); err != errors.ErrNodeNotFound {
+		t.Errorf("expected: %v, got: %v", errors.ErrNodeNotFound, err)
+	}
+
+	edgeX := entity.NewEdge(nodeX, nodeX)
+
+	if err := m.Delete(edgeX); err != errors.ErrNodeNotFound {
+		t.Errorf("expected: %v, got: %v", errors.ErrNodeNotFound, err)
 	}
 }
 
@@ -200,8 +303,8 @@ func TestQueryAllNodes(t *testing.T) {
 		t.Errorf("failed to query all nodes: %v", err)
 	}
 
-	if len(nodes) != m.Nodes().Len() {
-		t.Errorf("expected node count: %d, got: %d", m.Nodes().Len(), len(nodes))
+	if len(nodes) != len(m.Nodes()) {
+		t.Errorf("expected node count: %d, got: %d", len(m.Nodes()), len(nodes))
 	}
 
 	for _, nsKinds := range mock.ObjectData {
@@ -343,6 +446,11 @@ func TestSubgraph(t *testing.T) {
 		t.Fatalf("expected single node, got: %d", len(nodes))
 	}
 
+	// subgraph of non-existent node should return error
+	if _, err := m.SubGraph("", 10); err != errors.ErrNodeNotFound {
+		t.Errorf("expected: %v, got: %v", errors.ErrNodeNotFound, err)
+	}
+
 	node := nodes[0].(store.Node)
 
 	//NOTE: we know the number of expected nodesfrom the moc.ObjectLinks
@@ -356,13 +464,13 @@ func TestSubgraph(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		g, err := m.SubGraph(node, tc.depth)
+		g, err := m.SubGraph(node.ID(), tc.depth)
 		if err != nil {
 			t.Errorf("failed to query subgraph: %v", err)
 		}
 
-		if g.Nodes().Len() != tc.exp {
-			t.Errorf("expected subgraph nodes: %d, got: %d", tc.exp, g.Nodes().Len())
+		if len(g.Nodes()) != tc.exp {
+			t.Errorf("expected subgraph nodes: %d, got: %d", tc.exp, len(g.Nodes()))
 		}
 	}
 }
@@ -372,10 +480,6 @@ func TestDOT(t *testing.T) {
 	m, err := NewStore(id)
 	if err != nil {
 		t.Fatalf("failed to create new memory store: %v", err)
-	}
-
-	if m == nil {
-		t.Fatal("failed to create new memory store")
 	}
 
 	dotGraph := m.(store.DOTGraph)

--- a/store/memory/node.go
+++ b/store/memory/node.go
@@ -1,0 +1,28 @@
+package memory
+
+import "github.com/milosgajdos/kraph/store"
+
+type node struct {
+	store.Node
+	id   int64
+	name string
+}
+
+func (n *node) ID() int64 {
+	return n.id
+}
+
+// DOTID returns the node's DOT ID.
+func (n *node) DOTID() string {
+	dotNode, ok := n.Node.(store.DOTNode)
+	if ok {
+		return dotNode.DOTID()
+	}
+
+	return n.Node.ID()
+}
+
+// SetDOTID sets the node's DOT ID.
+func (n *node) SetDOTID(id string) {
+	n.name = id
+}

--- a/store/store.go
+++ b/store/store.go
@@ -3,7 +3,6 @@ package store
 import (
 	"github.com/milosgajdos/kraph/api"
 	"github.com/milosgajdos/kraph/query"
-	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/encoding"
 )
 
@@ -65,23 +64,19 @@ type DOTNode interface {
 // Node is a graph node
 type Node interface {
 	Entity
-	graph.Node
-	// Name returns node name
-	Name() string
+	// ID returns node ID
+	ID() string
 }
 
 // Edge is an edge between two nodes
 type Edge interface {
 	Entity
-	graph.WeightedEdge
-}
-
-// Graph is a graph of API objects
-type Graph interface {
-	graph.Graph
-	// Subgraph returns a subgraph of the graph starting at Node
-	// up to the given depth or it returns an error
-	SubGraph(Node, int) (graph.Graph, error)
+	// From returns the from node of the edge
+	From() Node
+	// To returns the to node of the edge.
+	To() Node
+	// Weight returns edge weight
+	Weight() float64
 }
 
 // DOTGraph returns Graphiz DOT store
@@ -93,6 +88,21 @@ type DOTGraph interface {
 	DOTAttributers() (graph, node, edge encoding.Attributer)
 	// DOT returns Graphviz graph
 	DOT() (string, error)
+}
+
+// Graph is a graph of API objects
+type Graph interface {
+	// Node returns the node with the given ID if it exists
+	// in the graph, and nil otherwise.
+	Node(id string) Node
+	// Nodes returns all the nodes in the graph.
+	Nodes() []Node
+	// Edge returns the edge from u to v, with IDs uid and vid,
+	// if such an edge exists and nil otherwise
+	Edge(uid, vid string) Edge
+	// Subgraph returns a subgraph of the graph starting at Node
+	// up to the given depth or it returns an error
+	SubGraph(id string, depth int) (Graph, error)
 }
 
 // Store allows to store and query the graph of API objects


### PR DESCRIPTION
Originally `store.Store` was embedding `store.Graph` which itself was `graph.Graph` (more precisely, `gonum.Graph`). This was polluting the store interfaces and frankly wasn't ideal as it required implementation of some functions which were not necessary for the program functionality.

This PR  cleans this mess up. This has also a benefit of having application-specific node `ID`s as opposed to the number id required by `gonum.Graph` which are often hard to extract from graph databases and they really should not be!

This PR also cleans up memory store tests and adds a bit more test coverage to memory package.